### PR TITLE
ask community to join Zulip (instead of Matrix) #22

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,33 +31,32 @@
       </div>
       <div class="col-lg-6 mx-auto">
         <p class="lead mb-4">
-          Welcome! To chat with Dataverse users and developers, please check out
-          the
-          <a href="https://archive.matrix.org/r/dataverse:matrix.org">log</a>
-          of recent conversation and join us in #dataverse on Matrix.
+          Hello! To chat with Dataverse users and developers, please join us in
+          <a href="https://dataverse.zulipchat.com">Zulip</a>!
+        </p>
+        <p class="lead mb-4">
+          Before signing up, you are welcome to browse the
+          <a href="https://dataverse.zulipchat.com">archive of messages</a>,
+          especially the
+          <a
+            href="https://dataverse.zulipchat.com/#narrow/stream/375707-community/topic/hello.20I'm.20new.20here"
+            >hello, I'm new here</a
+          >
+          topic.
         </p>
         <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mb-3">
           <a
-            href="https://archive.matrix.org/r/dataverse:matrix.org"
+            href="https://dataverse.zulipchat.com"
             class="btn btn-primary btn-lg px-4 me-sm-3"
             role="button"
-            >View Log</a
+            >View Archive</a
           >
           <a
-            href="https://matrix.to/#/#dataverse:matrix.org"
+            href="https://dataverse.zulipchat.com"
             class="btn btn-outline-secondary btn-lg px-4"
             role="button"
-            >Join Chat</a
+            >Join Zulip</a
           >
-        </div>
-        <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mb-3">
-          <a
-            href="https://view.matrix.org/room/!AmypvmJtUjBesRrnLM:matrix.org/members?page=0"
-            style="display: none"
-            ><img
-              alt="count of people who have joined chat"
-              src="https://img.shields.io/matrix/dataverse:matrix.org.svg?label=Chatting&server_fqdn=matrix.org&logo=matrix&color=%23c55b28"
-          /></a>
         </div>
       </div>
       <div class="col-lg-4 mx-auto">
@@ -65,31 +64,48 @@
           <summary>More Information</summary>
           <p>
             chat.dataverse.org is the landing page for Dataverse Chat, but the
-            conversation happens in the
-            <a href="https://matrix.to/#/#dataverse:matrix.org">#dataverse</a>
-            room on <a href="https://matrix.org">matrix.org</a>, the flagship
-            server for a federated, open standard communication protocol called
-            Matrix.
+            conversation happens in our instance of Zulip at
+            <a href="https://dataverse.zulipchat.com"
+              >https://dataverse.zulipchat.com</a
+            >
           </p>
           <p>
-            For transparency, logs of the conversation are public and can be
-            seen at
-            <a href="https://archive.matrix.org/r/dataverse:matrix.org"
-              >archive.matrix.org/r/dataverse:matrix.org</a
-            >.
+            For more on Zulip, please see
+            <a href="https://zulip.com">zulip.com</a>,
+            <a href="https://en.wikipedia.org/wiki/Zulip">Zulip on Wikipedia</a
+            >, our issue about
+            <a href="https://github.com/IQSS/chat.dataverse.org/issues/22"
+              >switching from IRC to Matrix to Zulip</a
+            >, an
+            <a
+              href="https://www.pythonpodcast.com/zulip-chat-with-tim-abbott-episode-118/"
+              >interview with the founder</a
+            >, and our
+            <a
+              href="https://dataverse.zulipchat.com/#narrow/stream/375876-zulip"
+              >zulip</a
+            >
+            stream (where we talk about Zulip itself).
           </p>
           <p>
-            We are experimenting with another chat system called Zulip,
-            especially for working groups. You are welcome to join at
-            <a href="https://dataverse.zulipchat.com">dataverse.zulipchat.com</a
-            >.
+            Matrix has been a nice home ever since we had to
+            <a
+              href="https://groups.google.com/g/dataverse-community/c/KU0FDNb8ckM/m/bO8ZXv2WAQAJ"
+              >quickly get off IRC</a
+            >, but it probably doesn't make sense to keep both Matrix and Zulip.
           </p>
+
           <p>
-            Your ideas about chat are welcome! Please give feedback in chat or
-            open an
+            Your ideas about chat are welcome! Please give feedback in the
+            <a
+              href="https://dataverse.zulipchat.com/#narrow/stream/375876-zulip"
+              >zulip</a
+            >
+            stream or open an
             <a href="https://github.com/IQSS/chat.dataverse.org/issues">issue</a
             >.
           </p>
+
           <p>Artwork by Erika Durbin.</p>
         </details>
       </div>


### PR DESCRIPTION
The call to action on https://chat.dataverse.org as been to join Matrix ever since we moved from IRC in 2021: https://groups.google.com/g/dataverse-community/c/KU0FDNb8ckM/m/bO8ZXv2WAQAJ

For reasons highlighted in the following issue...

- #22 

... I think it's time to ask people to try Zulip instead.

In short, Zulip can be configured like Gitter (RIP). Messages can be read without logging in. You can readily link from Zulip messages to GitHub issues to mailing list posts, all with perfect transparency and no barriers to reading and learning. Zulip is a fabulous tool for open source projects!

Here's a screenshot of how our chat homepage will look after merging this pull request.

![Screenshot 2023-09-16 at 12-11-33 chat dataverse org](https://github.com/IQSS/chat.dataverse.org/assets/21006/dc3a8957-7c81-4a74-9def-57228ab28df5)
